### PR TITLE
Add dedicated impls for PluralOperands::from for integers, avoid unnecessary string allocations

### DIFF
--- a/intl_pluralrules/src/lib.rs
+++ b/intl_pluralrules/src/lib.rs
@@ -115,7 +115,7 @@ impl IntlPluralRules {
     /// assert_eq!(pr_naq.select(2), Ok(PluralCategory::TWO));
     /// assert_eq!(pr_naq.select(5), Ok(PluralCategory::OTHER));
     /// ```
-    pub fn select<N: ToString>(&self, number: N) -> Result<PluralCategory, &'static str> {
+    pub fn select<N: operands::IntoPluralOperands>(&self, number: N) -> Result<PluralCategory, &'static str> {
         let ops = operands::PluralOperands::from(number);
         let pr = self.function;
         match ops {


### PR DESCRIPTION
Currently we always convert to a string before parsing. This has two
problems:

 - For `&str` inputs, we unconditionally copy and allocate despite never
needing a `String`
 - For integers, we spend extra time reparsing back to an integer

This uses a new trait so that we can specialize the implementation and
be fast for the common cases.

part of https://github.com/unclenachoduh/pluralrules/issues/14

r? @unclenachoduh @zbraniecki